### PR TITLE
export getreusedtimes method from socket

### DIFF
--- a/lib/resty/beanstalkd.lua
+++ b/lib/resty/beanstalkd.lua
@@ -42,6 +42,14 @@ function _M.set_keepalive(self, ...)
     return sock:setkeepalive(...)
 end
 
+function _M.getreusedtimes(self)
+    local sock = self.sock
+    if not sock then
+        return nil, "not initialized"
+    end
+    return sock:getreusedtimes()
+end
+
 function _M.connect(self, host, port, ...)
     local sock = self.sock
     if not sock then


### PR DESCRIPTION
We have built a high level connections pool acording to the using tubes. And it's required to export the `getreusedtimes` in the level of `lua-resty-beanstalkd`. Now maybe it is time to push this feature back to the upstream 😄 