### PR TITLE
fix watch/ignore return value

### DIFF
--- a/lib/resty/beanstalkd.lua
+++ b/lib/resty/beanstalkd.lua
@@ -95,7 +95,7 @@ function _M.watch(self, tube)
     if size then
         return size, line
     end
-    return 0, line
+    return nil, line
 end
 
 function _M.ignore(self, tube)
@@ -116,7 +116,7 @@ function _M.ignore(self, tube)
     if size then
         return size, line
     end
-    return 0, line
+    return nil, line
 end
 
 function _M.put(self, body, pri, delay, ttr)


### PR DESCRIPTION
Return (nil, msg) when beanstalkd replies error message, so that we
could capture it with `if not ok then ...`